### PR TITLE
chore: add expo plugins configuration for IOS

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/commonjs/plugin/withReactNativeRateApp');

--- a/package.json
+++ b/package.json
@@ -86,9 +86,13 @@
     "@types/react": "19.0.8"
   },
   "peerDependencies": {
-    "expo": ">=47.0.0",
     "react": "*",
     "react-native": "*"
+  },
+  "peerDependenciesMeta": {
+    "expo": {
+      "optional": true
+    }
   },
   "workspaces": [
     "example"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",
-    "!**/.*"
+    "!**/.*",
+    "app.plugin.js"
   ],
   "scripts": {
     "example": "yarn workspace react-native-rate-app-example",
@@ -71,6 +72,7 @@
     "@types/react": "19.0.8",
     "commitlint": "19.7.1",
     "del-cli": "6.0.0",
+    "expo": "^52.0.31",
     "husky": "9.1.7",
     "jest": "29.7.0",
     "react": "19.0.0",
@@ -84,6 +86,7 @@
     "@types/react": "19.0.8"
   },
   "peerDependencies": {
+    "expo": ">=47.0.0",
     "react": "*",
     "react-native": "*"
   },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react": "19.0.0",
     "react-native": "0.77.0",
     "react-native-builder-bob": "0.37.0",
-    "semantic-release": "24.2.1",
+    "semantic-release": "24.2.2",
     "turbo": "2.4.0",
     "typescript": "5.7.3"
   },

--- a/src/plugin/withReactNativeRateApp.ts
+++ b/src/plugin/withReactNativeRateApp.ts
@@ -1,0 +1,45 @@
+import { withInfoPlist, withXcodeProject } from "@expo/config-plugins";
+import type { ConfigPlugin } from "expo/config-plugins";
+
+/**
+ * Modifies the `Info.plist` file to add `LSApplicationQueriesSchemes`,
+ * allowing the app to open App Store links.
+ *
+ * @param {ConfigPlugin} config - The Expo configuration object.
+ * @returns {ConfigPlugin} - The modified Expo configuration.
+ */
+const withCustomInfoPlist: ConfigPlugin = (config) => {
+  return withInfoPlist(config, (config) => {
+    config.modResults.LSApplicationQueriesSchemes = ["itms-apps"];
+    return config;
+  });
+};
+
+/**
+ * Adds the `StoreKit.framework` to the iOS Xcode project.
+ * This framework is required for in-app review prompts.
+ *
+ * @param {ConfigPlugin} config - The Expo configuration object.
+ * @returns {ConfigPlugin} - The modified Expo configuration.
+ */
+const withStoreKitFramework: ConfigPlugin = (config) => {
+  return withXcodeProject(config, (config) => {
+    config.modResults.addFramework("StoreKit.framework", { required: true });
+    return config;
+  });
+};
+
+/**
+ * Applies both `withCustomInfoPlist` and `withStoreKitFramework`
+ * to enable in-app rating functionality in a React Native app.
+ *
+ * @param {ConfigPlugin} config - The Expo configuration object.
+ * @returns {ConfigPlugin} - The modified Expo configuration.
+ */
+const withReactNativeRateApp: ConfigPlugin = (config) => {
+  config = withCustomInfoPlist(config);
+  config = withStoreKitFramework(config);
+  return config;
+};
+
+export default withReactNativeRateApp;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10461,7 +10461,7 @@ __metadata:
     react: "npm:19.0.0"
     react-native: "npm:0.77.0"
     react-native-builder-bob: "npm:0.37.0"
-    semantic-release: "npm:24.2.1"
+    semantic-release: "npm:24.2.2"
     turbo: "npm:2.4.0"
     typescript: "npm:5.7.3"
   peerDependencies:
@@ -10878,9 +10878,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semantic-release@npm:24.2.1":
-  version: 24.2.1
-  resolution: "semantic-release@npm:24.2.1"
+"semantic-release@npm:24.2.2":
+  version: 24.2.2
+  resolution: "semantic-release@npm:24.2.2"
   dependencies:
     "@semantic-release/commit-analyzer": "npm:^13.0.0-beta.1"
     "@semantic-release/error": "npm:^4.0.0"
@@ -10913,7 +10913,7 @@ __metadata:
     yargs: "npm:^17.5.1"
   bin:
     semantic-release: bin/semantic-release.js
-  checksum: 10/6fe86670e37455443f9e9189c83a99772bc9b0ee88fd42160733d9f3816bb02cb5043beb6ad9af6179595373abf49ec065a2f261fea5b9fd20a37711f5dfece4
+  checksum: 10/543e0be294e59172a58ceff2f9f1a29968304af55ebc92f9e59d1e0da36d64b094fe12e469eb3c1c6ab6bb5d698624876093f78aa17702169b2770cbad029e21
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Hi @huextrat,

This PR introduces an Expo plugin configuration for react-native-rate-app, ensuring that necessary iOS settings persist after running npx expo prebuild.

Now, Expo users can simply add the plugin to their app.json without manually modifying Info.plist or adding StoreKit.framework:

`"plugins": [
      "react-native-rate-app",
      ...
    ],`
    
Let me know if you need any refinements! 😊

PS: I forgot to add for no Expo users in package.json:

```
"peerDependenciesMeta": {
    "expo": {
      "optional": true
    }
  }
```