### PR TITLE
Change onActivityResult and onNewIntent parameter types

### DIFF
--- a/android/src/main/java/com/rateapp/RateAppModule.kt
+++ b/android/src/main/java/com/rateapp/RateAppModule.kt
@@ -115,7 +115,7 @@ class RateAppModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  fun onNewIntent(intent: Intent) {
+  override fun onNewIntent(intent: Intent) {
     // No-op
   }
 


### PR DESCRIPTION
Changed param types of both functions based on the latest RN 0.80.0 release and changes made to `ActivityEventListener` ([changes](https://github.com/facebook/react-native/pull/49910))